### PR TITLE
Only push images on ref_type tag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Login to Container Registry
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && steps.img-metadata.outputs.tags != github.event.repository.default_branch }}
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
         with:
           registry: ${{ env.REGISTRY }}
@@ -119,7 +119,7 @@ jobs:
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && steps.img-metadata.outputs.tags != github.event.repository.default_branch }}
           tags: ${{ steps.img-metadata.outputs.tags }}
           labels: ${{ steps.img-metadata.outputs.labels }}
           platforms: linux/amd64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Login to Container Registry
-        if: ${{ github.event_name != 'pull_request' && steps.img-metadata.outputs.tags != github.event.repository.default_branch }}
+        if: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20
         with:
           registry: ${{ env.REGISTRY }}
@@ -119,7 +119,7 @@ jobs:
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' && steps.img-metadata.outputs.tags != github.event.repository.default_branch }}
+          push: ${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
           tags: ${{ steps.img-metadata.outputs.tags }}
           labels: ${{ steps.img-metadata.outputs.labels }}
           platforms: linux/amd64


### PR DESCRIPTION
Push to main is filling up ghcr with untagged images since they all use same tags. Will only push when images are tagged.

Tags shouldn't be deleted